### PR TITLE
添加defination(s)注解以及增加response指定scheame的$ref特性

### DIFF
--- a/src/Annotation/ApiDefinition.php
+++ b/src/Annotation/ApiDefinition.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace Hyperf\Apidog\Annotation;
+
+use Hyperf\Di\Annotation\AbstractAnnotation;
+
+/**
+ * @Annotation
+ * @Target({"ALL"})
+ */
+class ApiDefinition extends AbstractAnnotation
+{
+    public $name;
+    public $properties;
+}

--- a/src/Annotation/ApiDefinitions.php
+++ b/src/Annotation/ApiDefinitions.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Hyperf\Apidog\Annotation;
+
+use Hyperf\Di\Annotation\AbstractAnnotation;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ */
+class ApiDefinitions extends AbstractAnnotation
+{
+    /**
+     * @var array
+     */
+    public $definitions;
+    
+    public function __construct($value = null)
+    {
+        $this->bindMainProperty('definitions', $value);
+    }
+}

--- a/src/Swagger/SwaggerJson.php
+++ b/src/Swagger/SwaggerJson.php
@@ -275,12 +275,13 @@ class SwaggerJson
             /** @var $definition ApiDefinition */
             $defName = $definition->name;
             $defProps = $definition->properties;
-            $formatedProps = [];
+            $formattedProps = [];
 
             foreach ($defProps as $propKey => $prop) {
-                [$propName, $propAlias] = explode('|', $propKey);
+                $propKeyArr = explode('|', $propKey);
+                $propName = $propKeyArr[0];
                 $propVal = [];
-                $propAlias && $propVal['description'] = $propAlias;
+                isset($propKeyArr[1]) && $propVal['description'] = $propKeyArr[1];
                 if (is_array($prop)) {
                     if (isset($prop['description']) && is_string($prop['description'])) {
                         $propVal['description'] = $prop['description'];
@@ -303,9 +304,9 @@ class SwaggerJson
                     $propVal['defalut'] = $prop;
                     $propVal['type'] = is_numeric($prop) ? 'integer': 'string';
                 }
-                $formatedProps[$propName] = $propVal;
+                $formattedProps[$propName] = $propVal;
             }
-            $this->swagger['definitions'][$defName]['properties'] = $formatedProps;
+            $this->swagger['definitions'][$defName]['properties'] = $formattedProps;
         }
 
     }

--- a/src/Swagger/SwaggerJson.php
+++ b/src/Swagger/SwaggerJson.php
@@ -266,7 +266,7 @@ class SwaggerJson
     public function makeDefinition($definitions)
     {
         if (!$definitions) {
-            return false;
+            return;
         }
         if ($definitions instanceof ApiDefinitions) {
             $definitions = $definitions->definitions;
@@ -292,8 +292,8 @@ class SwaggerJson
                     }
 
                     if (isset($prop['default'])) {
-                        $propVal['defalut'] = $prop['default'];
-                        !isset($propVal['type']) && $propVal['type'] = is_numeric($default) ? 'integer': 'string';
+                        $propVal['default'] = $prop['default'];
+                        !isset($propVal['type']) && $propVal['type'] = is_numeric($propVal['default']) ? 'integer': 'string';
                     }
 
                     if (isset($prop['$ref'])) {
@@ -301,14 +301,13 @@ class SwaggerJson
                         $propVal['$ref'] = '#/definitions/' . $prop['$ref'];
                     }
                 } else {
-                    $propVal['defalut'] = $prop;
+                    $propVal['default'] = $prop;
                     $propVal['type'] = is_numeric($prop) ? 'integer': 'string';
                 }
                 $formattedProps[$propName] = $propVal;
             }
             $this->swagger['definitions'][$defName]['properties'] = $formattedProps;
         }
-
     }
 
     public function responseSchemaToDefinition($schema, $modelName, $level = 0)


### PR DESCRIPTION
## 使用场景
复用相同格式的 *Response* 算是较为常见的，比如 `获取用户信息: GET /user/{id}` 与 `修改用户信息: POST /user/{id}` 接口都需要返回最新的用户信息。此时如果可以复用 *Response*，在写api注释时候会减少很多工作量。参照 **apidoc** 的形式，提供了定义*Response* 的功能。

## 一些说明
1. 通常是一个controller下的接口会存在响应复用情况，所以 `ApiDefinitions` 设为Class级了，而 `ApiDefinition` 似乎不定义成ALL 是不可以写在注解中（或许我还每研究透彻吧）
2. 如果只写 `@ApiDefinition` 注解，只会保留最后一个
3. `@ApiRespone` 注解中的 `scheme.$ref`的属性会变为优先级最高

## 使用例子

```php
/**
 * @ApiController(tag="用户管理", description="用户的新增/修改/删除接口")
 * @ApiDefinitions({
 *  @ApiDefinition(name="OkResponse", properties={
 *     "code|响应码": 200,
 *     "msg|响应信息": "ok",
 *     "data|响应数据": {"$ref": "UserInfoData"}
 *  }),
 *  @ApiDefinition(name="UserInfoData", properties={
 *     "userInfo|用户数据": {"$ref": "UserInfoDetail"}
 *  }),
 *  @ApiDefinition(name="UserInfoDetail", properties={
 *     "id|用户ID": 1,
 *     "mobile|用户手机号": "13545321231"
 *  })
 * })
 */
class UserController extends AbstractController
{
    /**
     * @Author 刀刀
     * @PostApi(path="/user", description="添加一个用户")
     * @Header(key="token|接口访问凭证", rule="required")
     * @FormData(key="name|名称", rule="required|max:10|cb_checkName")
     * @FormData(key="sex|年龄", rule="integer|in:0,1")
     * @FormData(key="file|文件", rule="file")
     * @ApiResponse(code="-1", description="参数错误")
     * @ApiResponse(code="0", description="创建成功", schema={"$ref": "OkResponse"})
     */
    public function add()
    {
        return 'test';
    }
}
```

## 运行效果
![image](https://user-images.githubusercontent.com/59111601/92214819-a5c04d00-eec6-11ea-936f-cdebb166e76e.png)
![image](https://user-images.githubusercontent.com/59111601/92214955-aeb11e80-eec6-11ea-958a-93cc006fd68b.png)
