### PR TITLE
 fix bug

### DIFF
--- a/publish/apidog.php
+++ b/publish/apidog.php
@@ -16,6 +16,7 @@ return [
     'http_status_code' => 400,
     'field_error_code' => 'code',
     'field_error_message' => 'message',
+    'exception_enable' => false,
     // swagger 的基础配置
     'swagger' => [
         'swagger' => '2.0',

--- a/publish/apidog.php
+++ b/publish/apidog.php
@@ -28,4 +28,24 @@ return [
         'host' => 'apidog.cc',
         'schemes' => ['http'],
     ],
+    'templates' => [
+        // {template} 字面变量  替换 schema 内容
+//        // 默认 成功 返回
+//        'success' => [
+//            "code|code"    => '0',
+//            "result"  => '{template}',
+//            "message|message" => 'Success',
+//        ],
+//        // 分页
+//        'page' => [
+//            "code|code"    => '0',
+//            "result"  => [
+//                'pageSize' => 10,
+//                'total' => 1,
+//                'totalPage' => 1,
+//                'list' => '{template}'
+//            ],
+//            "message|message" => 'Success',
+//        ],
+    ],
 ];

--- a/src/Annotation/ApiResponse.php
+++ b/src/Annotation/ApiResponse.php
@@ -13,6 +13,7 @@ class ApiResponse extends AbstractAnnotation
     public $code;
     public $description;
     public $schema;
+    public $template;
 
     public function __construct($value = null)
     {

--- a/src/Annotation/Header.php
+++ b/src/Annotation/Header.php
@@ -6,7 +6,7 @@ use Hyperf\Di\Annotation\AbstractAnnotation;
 
 /**
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"METHOD", "CLASS"})
  */
 class Header extends Param
 {

--- a/src/Annotation/Query.php
+++ b/src/Annotation/Query.php
@@ -4,7 +4,7 @@ namespace Hyperf\Apidog\Annotation;
 
 /**
  * @Annotation
- * @Target({"METHOD"})
+ * @Target({"METHOD", "CLASS"})
  */
 class Query extends Param
 {

--- a/src/Exception/ApiDocException.php
+++ b/src/Exception/ApiDocException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Hyperf\Apidog\Exception;
+
+use Hyperf\Server\Exception\ServerException;
+
+class ApiDocException extends ServerException
+{
+
+}

--- a/src/Exception/ApiDogException.php
+++ b/src/Exception/ApiDogException.php
@@ -4,7 +4,7 @@ namespace Hyperf\Apidog\Exception;
 
 use Hyperf\Server\Exception\ServerException;
 
-class ApiDocException extends ServerException
+class ApiDogException extends ServerException
 {
 
 }

--- a/src/Middleware/ApiValidationMiddleware.php
+++ b/src/Middleware/ApiValidationMiddleware.php
@@ -60,7 +60,7 @@ class ApiValidationMiddleware extends CoreMiddleware
             $exceptionEnable = $config->get('apidog.exception_enable', false);
             if ($exceptionEnable) {
                 $fieldErrorMessage = $config->get('apidog.field_error_message', 'message');
-                throw new ApiDocException(0, $fieldErrorMessage);
+                throw new ApiDocException($fieldErrorMessage);
             }
             $httpStatusCode = $config->get('apidog.http_status_code', 400);
             return $this->response->json($result)->withStatus($httpStatusCode);

--- a/src/Middleware/ApiValidationMiddleware.php
+++ b/src/Middleware/ApiValidationMiddleware.php
@@ -13,6 +13,8 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Apidog\Exception\ApiDocException;
 
 class ApiValidationMiddleware extends CoreMiddleware
 {
@@ -27,11 +29,6 @@ class ApiValidationMiddleware extends CoreMiddleware
     protected $response;
 
     protected $validationApi;
-
-    /**
-     * @Value("apidog.http_status_code")
-     */
-    private $httpStatusCode;
 
     public function __construct(ContainerInterface $container, HttpResponse $response, RequestInterface $request, ValidationApi $validation)
     {
@@ -59,7 +56,14 @@ class ApiValidationMiddleware extends CoreMiddleware
 
         $result = $this->validationApi->validated($controller, $action);
         if ($result !== true) {
-            return $this->response->json($result)->withStatus($this->httpStatusCode);
+            $config = $this->container->get(ConfigInterface::class);
+            $exceptionEnable = $config->get('apidog.exception_enable', false);
+            if ($exceptionEnable) {
+                $fieldErrorMessage = $config->get('apidog.field_error_message', 'message');
+                throw new ApiDocException(0, $fieldErrorMessage);
+            }
+            $httpStatusCode = $config->get('apidog.http_status_code', 400);
+            return $this->response->json($result)->withStatus($httpStatusCode);
         }
 
         return $handler->handle($request);

--- a/src/Middleware/ApiValidationMiddleware.php
+++ b/src/Middleware/ApiValidationMiddleware.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Hyperf\Contract\ConfigInterface;
-use Hyperf\Apidog\Exception\ApiDocException;
+use Hyperf\Apidog\Exception\ApiDogException;
 
 class ApiValidationMiddleware extends CoreMiddleware
 {
@@ -60,7 +60,7 @@ class ApiValidationMiddleware extends CoreMiddleware
             $exceptionEnable = $config->get('apidog.exception_enable', false);
             if ($exceptionEnable) {
                 $fieldErrorMessage = $config->get('apidog.field_error_message', 'message');
-                throw new ApiDocException($fieldErrorMessage);
+                throw new ApiDogException($result[$fieldErrorMessage]);
             }
             $httpStatusCode = $config->get('apidog.http_status_code', 400);
             return $this->response->json($result)->withStatus($httpStatusCode);

--- a/src/Swagger/SwaggerJson.php
+++ b/src/Swagger/SwaggerJson.php
@@ -455,12 +455,12 @@ class SwaggerJson
         $pathInfo = pathinfo($file);
         if (!empty($pathInfo['dirname'])) {
             if (file_exists($pathInfo['dirname']) === false) {
-                if (@mkdir($pathInfo['dirname'], 0777, true) === false) {
+                if (mkdir($pathInfo['dirname'], 0777, true) === false) {
                     return false;
                 }
             }
         }
-        return @file_put_contents($file, $content);
+        return file_put_contents($file, $content);
     }
 
     public function save()

--- a/src/Swagger/SwaggerJson.php
+++ b/src/Swagger/SwaggerJson.php
@@ -392,6 +392,19 @@ class SwaggerJson
         return $definition;
     }
 
+    public function putFile(string $file, string $content)
+    {
+        $pathInfo = pathinfo($file);
+        if (!empty($pathInfo['dirname'])) {
+            if (file_exists($pathInfo['dirname']) === false) {
+                if (@mkdir($pathInfo['dirname'], 0777, true) === false) {
+                    return false;
+                }
+            }
+        }
+        return @file_put_contents($file, $content);
+    }
+
     public function save()
     {
         $this->swagger['tags'] = array_values($this->swagger['tags'] ?? []);
@@ -401,7 +414,7 @@ class SwaggerJson
             return;
         }
         $outputFile = str_replace('{server}', $this->server, $outputFile);
-        file_put_contents($outputFile, json_encode($this->swagger, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $this->putFile($outputFile, json_encode($this->swagger, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         $this->logger->debug('Generate swagger.json success!');
     }
 }

--- a/src/Swagger/SwaggerJson.php
+++ b/src/Swagger/SwaggerJson.php
@@ -21,7 +21,6 @@ use Hyperf\HttpServer\Annotation\Mapping;
 use Hyperf\Logger\LoggerFactory;
 use Hyperf\Utils\ApplicationContext;
 use Hyperf\Utils\Arr;
-use Lengbin\Helper\YiiSoft\Arrays\ArrayHelper;
 
 class SwaggerJson
 {


### PR DESCRIPTION
  - 修复 初始化 swagger.json  文件生成
  - 修复 definition 在swagger ui 正确显示 定义数据类型
  - 添加 注解 Header ，Query 支持 类 注解
  - 添加 FormData 注解 key 参数 支持 a.b 验证 swagger ui 支持
  - 添加 Body 注解 支持 参数 a.b  和 a.*.b 验证 swagger ui 支持
  - 修复 definition 返回 参数为 小数在 swagger ui 不显示问题
  - 添加 异常 ApiDogException 抛出，以及配置 异常抛出开关
  - 添加 返回数据 模版 